### PR TITLE
Added Vagrantfile, updated references to Google test frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ build/
 *.bin
 *.vec
 
+# Vagrant folder
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,20 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "box-cutter/ubuntu1604-desktop"
-  
+
   config.vm.provider "virtualbox" do |v|
     v.gui = true
   end
+
+  config.vm.provision "shell" do |s|
+    s.inline = $provisioner
+  end
 end
+
+$provisioner = <<SCRIPT
+echo Updating package sources...
+sudo apt update
+echo Upgrading packages...
+sudo apt full-upgrade -y
+echo Installing `cmake`...
+sudo apt install cmake -y
+SCRIPT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,7 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "box-cutter/ubuntu1604-desktop"
+  
+  config.vm.provider "virtualbox" do |v|
+    v.gui = true
+  end
+end

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ExternalProject)
 # Download and install GoogleTest
 ExternalProject_Add(
         gtest
-        URL https://googletest.googlecode.com/files/gtest-1.7.0.zip
+        URL https://github.com/google/googletest/archive/release-1.8.0.zip
         PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gtest
         # Disable install step
         INSTALL_COMMAND ""
@@ -33,8 +33,7 @@ include_directories("${source_dir}/include")
 # Download and install GoogleMock
 ExternalProject_Add(
         gmock
-        URL https://googlemock.googlecode.com/files/gmock-1.7.0.zip
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gmock
+        URL https://github.com/google/googlemock/archive/release-1.7.0.zip        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gmock
         # Disable install step
         INSTALL_COMMAND ""
 )


### PR DESCRIPTION
I was following along with your tutorial and thought it might be helpful to add a Vagrantfile to get up and running quickly. It looks as though this project has gone stale though; do you have plans to restart development on it?

Also, although I was able to get the references sorted out for the Google test frameworks, I received an error while running `cmake --build build -- all test`:

![image](https://cloud.githubusercontent.com/assets/3596873/20778455/bd7b7b02-b73b-11e6-9022-8f291df6bce6.png)
